### PR TITLE
Add flock helper, improve config test, and update install docs

### DIFF
--- a/commands/install.sh
+++ b/commands/install.sh
@@ -6,9 +6,9 @@ Usage: xrf install [--version vX.Y.Z|latest] [--topology reality-only|vision-rea
 Env:
   XRAY_SNIFFING=false|true
   # reality-only
-  XRAY_PORT=443 XRAY_UUID=<uuid> XRAY_REALITY_SNI=www.microsoft.com[,alt] XRAY_REALITY_DEST=www.microsoft.com XRAY_PRIVATE_KEY=<x25519> XRAY_SHORT_ID=<hex>
+  XRAY_PORT=443 XRAY_UUID=<uuid> XRAY_REALITY_SNI=www.microsoft.com[,alt] XRAY_REALITY_DEST=www.microsoft.com XRAY_PRIVATE_KEY=<X25519> XRAY_SHORT_ID=<hex>
   # vision-reality
-  XRAY_VISION_PORT=8443 XRAY_REALITY_PORT=443 XRAY_UUID_VISION=<uuid> XRAY_UUID_REALITY=<uuid> XRAY_DOMAIN=example.com XRAY_CERT_DIR=/usr/local/etc/xray/certs XRAY_PRIVATE_KEY=<x25519> XRAY_SHORT_ID=<hex>
+  XRAY_VISION_PORT=8443 XRAY_REALITY_PORT=443 XRAY_FALLBACK_PORT=8080 XRAY_UUID_VISION=<uuid> XRAY_UUID_REALITY=<uuid> XRAY_DOMAIN=example.com XRAY_CERT_DIR=/usr/local/etc/xray/certs XRAY_PRIVATE_KEY=<X25519> XRAY_SHORT_ID=<hex>
 EOF
 }
 


### PR DESCRIPTION
## Summary
- add a core::with_flock helper so configuration updates really take an exclusive lock even when sudo is required
- surface `xray -test` failures with context to make config validation easier to debug
- document the fallback port and correct the X25519 spelling in the install usage text

## Testing
- make lint *(fails: shellcheck not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e6ed58c48321a1b3da8893aab5ed