### PR TITLE
Fix configure lock execution in same shell

### DIFF
--- a/services/xray/configure.sh
+++ b/services/xray/configure.sh
@@ -85,14 +85,18 @@ deploy_release(){
   core::log info "deployed" "$(printf '{"active":"%s"}' "$(xray::active)")"
 }
 
+deploy_with_lock(){
+  local topology="$1"
+  local d
+  d="$(render_release "$topology")"
+  deploy_release "$d"
+}
+
 main(){
   core::init "$@"
   local topology="reality-only"
   while [[ $# -gt 0 ]]; do case "$1" in --topology) topology="$2"; shift 2;; *) shift;; esac; done
   plugins::ensure_dirs; plugins::load_enabled
-  core::with_flock "$(state::lock)" bash -c '
-    d="$(render_release "'"${topology}"'")"
-    deploy_release "$d"
-  '
+  core::with_flock "$(state::lock)" deploy_with_lock "$topology"
 }
 main "$@"


### PR DESCRIPTION
## Summary
- ensure the configuration deployment under the flock runs in the current shell so helper functions remain available

## Testing
- `make lint` *(fails: shellcheck: command not found)*
- `XRAY_UUID=11111111-1111-1111-1111-111111111111 XRAY_PRIVATE_KEY=abc XRAY_PUBLIC_KEY=def XRAY_REALITY_SNI=example.com XRF_VAR=/tmp/xrf-test XRF_PREFIX=/tmp/xrf-prefix XRF_ETC=/tmp/xrf-etc ./services/xray/configure.sh --topology reality-only`

------
https://chatgpt.com/codex/tasks/task_e_68c8f6d313cc8321a23b3bd384bb8209